### PR TITLE
core: don't treat wasi as a browser in detect_operating_system

### DIFF
--- a/internal/core/lib.rs
+++ b/internal/core/lib.rs
@@ -100,7 +100,7 @@ pub type Coord = i32;
 /// parameter cannot be called from the public API without naming it
 pub struct InternalToken;
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(any(not(target_family = "wasm"), target_os = "wasi"))]
 pub fn detect_operating_system() -> OperatingSystemType {
     if cfg!(target_os = "android") {
         OperatingSystemType::Android
@@ -117,7 +117,7 @@ pub fn detect_operating_system() -> OperatingSystemType {
     }
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 pub fn detect_operating_system() -> OperatingSystemType {
     let mut user_agent =
         web_sys::window().and_then(|w| w.navigator().user_agent().ok()).unwrap_or_default();


### PR DESCRIPTION
`detect_operating_system()` has two cfg variants: a `cfg!(target_os = …)` one for `not(target_family = "wasm")`, and a `web_sys`-based one for `target_family = "wasm"`.

But `target_family = "wasm"` matches **both** browser wasm (`wasm32-unknown-unknown`/emscripten) **and WASI** (`wasm32-wasip1*`). Under WASI there is no DOM, so `web_sys::window()` doesn't resolve and i-slint-core fails to build:

```
error[E0425]: cannot find function `window` in crate `web_sys`
```

This blocks any std/WASI wasm host of Slint's software renderer (no browser, framebuffer-only) — e.g. running the UI under Wasmtime or in Web Workers over wasm32-wasip1-threads.

Fix: gate the `web_sys` path on `not(target_os = "wasi")`, and let WASI fall through to the `cfg!`-based detection (returns `Other`, since WASI is none of android/ios/macos/windows/linux). Browser behaviour is unchanged.
